### PR TITLE
fix GenerateJwe

### DIFF
--- a/src/api/jweutil.go
+++ b/src/api/jweutil.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"io"
 	"log"
+	"strings"
 )
 
 // GenerateJwe generate jwe
@@ -31,19 +32,19 @@ MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAgBJB4usbO33Xg5vhJqfHJsMZj44f7rxpjRuP
 -----END PUBLIC KEY-----
 `
 	encryptedKey := getEncryptedKey(sessionKey, sessionKeyPublicKey)
-	encryptedKeyEncode := base64.URLEncoding.EncodeToString([]byte(encryptedKey))
+	encryptedKeyEncode := base64.RawURLEncoding.EncodeToString([]byte(encryptedKey))
 
 	// Part 3: JWE IV
 	// Generate a 12-byte iv. Then convert it to a Hex String, and then do base64 encoding to the Hex String.
 	iv := generateSecureRandomFactor(12)
 	ivHexStr := hex.EncodeToString(iv)
-	ivEncode := base64.URLEncoding.EncodeToString([]byte(ivHexStr))
+	ivEncode := base64.RawURLEncoding.EncodeToString([]byte(ivHexStr))
 
 	// Part 4: JWE Cipher Text
 	// Encrypt the payload with sessionKey and iv using AES/GCM/NoPadding algorithm. Encode the cipher text into a
 	// Hex String. Then do gzip compression and base64 encoding to the Hex String.
 	cipherText := getCipherText(payload, sessionKey, iv)
-	cipherTextEncode := base64.URLEncoding.EncodeToString(cipherText)
+	cipherTextEncode := base64.RawURLEncoding.EncodeToString(cipherText)
 
 	// Part 5: JWE Signature
 	// Use your own private key to sign the content with SHA256withRSA, then do base64 encoding to it.
@@ -78,6 +79,7 @@ func getSignature(jweSignPrivateKey string, sessionKey string, payLoadJson strin
 }
 
 func getCipherText(payload string, sessionKey string, iv []byte) []byte {
+
 	block, err := aes.NewCipher([]byte(sessionKey))
 	if err != nil {
 		panic(err.Error())
@@ -92,9 +94,9 @@ func getCipherText(payload string, sessionKey string, iv []byte) []byte {
 
 	var b bytes.Buffer
 	w := gzip.NewWriter(&b)
-	defer w.Close()
-	w.Write([]byte(hex.EncodeToString(ciphertext)))
+	w.Write([]byte(strings.ToUpper(hex.EncodeToString(ciphertext))))
 	w.Flush()
+	w.Close()
 
 	return b.Bytes()
 }
@@ -135,5 +137,5 @@ func getEncodeHeader() string {
 	buffer.WriteString(", zip=")
 	buffer.WriteString(jweHeader["zip"])
 
-	return base64.URLEncoding.EncodeToString(buffer.Bytes())
+	return base64.RawURLEncoding.EncodeToString(buffer.Bytes())
 }

--- a/src/api/rsautil.go
+++ b/src/api/rsautil.go
@@ -31,7 +31,7 @@ func SignByPss(content, privateKey []byte) string {
 
 	// content - Signature
 	var opts rsa.PSSOptions
-	opts.SaltLength = rsa.PSSSaltLengthAuto // for simple example
+	opts.SaltLength = rsa.PSSSaltLengthEqualsHash // for simple example
 	newhash := crypto.SHA256
 	pssh := newhash.New()
 	pssh.Write(content)
@@ -61,7 +61,7 @@ func VerifySignPss(content, signature, publicKey []byte) bool {
 
 	// Verify Signature
 	var opts rsa.PSSOptions
-	opts.SaltLength = rsa.PSSSaltLengthAuto // for simple example
+	opts.SaltLength = rsa.PSSSaltLengthEqualsHash // for simple example
 	newhash := crypto.SHA256
 	pssh := newhash.New()
 	pssh.Write(content)
@@ -90,7 +90,6 @@ func Encrypt(content, publicKey []byte) []byte {
 		log.Printf("Error converting to Public Key: %v", err)
 		return nil
 	}
-
 	hash := sha256.New()
 	res, err := rsa.EncryptOAEP(hash, rand.Reader, pubKey, content, nil)
 	if err != nil {


### PR DESCRIPTION
**PR Description: Fix critical encoding/writer issues**  

1. **GZIP footer loss**: Fixed by explicitly closing `gzip.Writer` before reading the buffer to ensure footer (checksum/length) is written.  
2. **Base64 padding**: Replaced `base64.URLEncoding` with `RawURLEncoding` to omit padding (`=`) for standards-compliant URL-safe strings (e.g., JWT tokens).  
3. **PSS salt length**: Set `rsa.PSSSaltLengthEqualsHash` to enforce salt length matching hash size (RFC 8017 compliance), avoiding cross-implementation inconsistencies from `PSSSaltLengthAuto`.  

Each fix aligns with spec requirements and prevents data corruption/parsing errors.

**Verified JWE Data Generation**: After implementing the fixes.